### PR TITLE
Chapter support

### DIFF
--- a/lib/metadata_parser.rb
+++ b/lib/metadata_parser.rb
@@ -5,6 +5,7 @@ module SimpleDOI
       PROPERTIES = [
         :book_title,
         :book_series_title,
+        :chapter_title,
         :isbn,
         :eisbn,
         :journal_title,

--- a/lib/metadata_parser.rb
+++ b/lib/metadata_parser.rb
@@ -62,6 +62,20 @@ module SimpleDOI
         @contributors ||= []
       end
 
+      def publisher
+        # Return publisher name concatenated with place if available
+        # If would throw a method error for :+ on publisher_name if nil, to dump nil for the whole thing
+        publisher_name + (publisher_place ? "; #{publisher_place}" : "") rescue nil
+      end
+
+      def publisher_name
+        raise NotImplementedError
+      end
+
+      def publisher_place
+        raise NotImplementedError
+      end
+
       # Return all properties as a Hash
       def to_h
         hash = {}

--- a/lib/metadata_parser.rb
+++ b/lib/metadata_parser.rb
@@ -6,6 +6,7 @@ module SimpleDOI
         :book_title,
         :book_series_title,
         :chapter_title,
+        :chapter_number,
         :isbn,
         :eisbn,
         :journal_title,

--- a/lib/metadata_parser/citeproc_json_parser.rb
+++ b/lib/metadata_parser/citeproc_json_parser.rb
@@ -120,8 +120,12 @@ module SimpleDOI
         @json['DOI']
       end
 
-      def publisher
+      def publisher_name
         @json['publisher']&.strip
+      end
+
+      def publisher_place
+        @json['publisher-location']&.strip
       end
 
       def volume

--- a/lib/metadata_parser/unixref_xml_parser.rb
+++ b/lib/metadata_parser/unixref_xml_parser.rb
@@ -102,12 +102,15 @@ module SimpleDOI
       end
 
       def contributors
+        role_sequences = Hash.new(0)
         @contributors ||= (@xml.search(contributors_path).map.with_index(1) do |contributor, idx|
           Contributor.new(
             (contributor.search('./given_name').first.text.strip rescue nil),
             (contributor.search('./surname').first.text.strip rescue nil),
             (contributor.attr('contributor_role').strip rescue nil),
-            idx
+            # Incremenent each per role, so all <contributor> elements can be read at once
+            # while preserving author vs editor vs other sequences
+            role_sequences[contributor.attr('contributor_role')] += 1
           )
         end)
       end

--- a/lib/metadata_parser/unixref_xml_parser.rb
+++ b/lib/metadata_parser/unixref_xml_parser.rb
@@ -108,13 +108,6 @@ module SimpleDOI
         @url ||= (@xml.search("#{doi_path}/resource").first.text.strip rescue nil) || (@xml.search("#{XPATH_ROOT}//doi_data/resource").first.text.strip rescue nil)
       end
 
-      # needs implementation
-      def publisher
-        # Return publisher name concatenated with place if available
-        # If would throw a method error for :+ on publisher_name if nil, to dump nil for the whole thing
-        publisher_name + (publisher_place ? "; #{publisher_place}" : "") rescue nil
-      end
-
       def publisher_name
         @publisher_name ||= @xml.search("//publisher/publisher_name").first.text.strip rescue nil
       end

--- a/tests/fixtures/citeproc-book-chapter-1.json
+++ b/tests/fixtures/citeproc-book-chapter-1.json
@@ -1,0 +1,88 @@
+{
+  "indexed": {
+    "date-parts": [
+      [
+        2018,
+        3,
+        15
+      ]
+    ],
+    "date-time": "2018-03-15T12:02:35Z",
+    "timestamp": 1521115355766
+  },
+  "publisher-location": "Boston",
+  "reference-count": 0,
+  "publisher": "Kluwer Academic Publishers",
+  "content-domain": {
+    "domain": [],
+    "crossmark-restriction": false
+  },
+  "DOI": "10.1007/0-306-47144-2_2",
+  "type": "chapter",
+  "created": {
+    "date-parts": [
+      [
+        2005,
+        12,
+        19
+      ]
+    ],
+    "date-time": "2005-12-19T14:41:36Z",
+    "timestamp": 1135003296000
+  },
+  "page": "9-35",
+  "source": "Crossref",
+  "is-referenced-by-count": 9,
+  "title": "Cooperative Learning and Social Interdependence Theory",
+  "prefix": "10.1007",
+  "author": [
+    {
+      "given": "David W.",
+      "family": "Johnson",
+      "affiliation": []
+    },
+    {
+      "given": "Roger T.",
+      "family": "Johnson",
+      "affiliation": []
+    }
+  ],
+  "member": "297",
+  "container-title": "Theory and Research on Small Groups",
+  "original-title": [],
+  "link": [
+    {
+      "URL": "http://www.springerlink.com/index/pdf/10.1007/0-306-47144-2_2",
+      "content-type": "unspecified",
+      "content-version": "vor",
+      "intended-application": "similarity-checking"
+    }
+  ],
+  "deposited": {
+    "date-parts": [
+      [
+        2014,
+        1,
+        3
+      ]
+    ],
+    "date-time": "2014-01-03T14:54:18Z",
+    "timestamp": 1388760858000
+  },
+  "score": 1,
+  "subtitle": [],
+  "short-title": [],
+  "issued": {
+    "date-parts": [
+      [
+        null
+      ]
+    ]
+  },
+  "ISBN": [
+    "0306456796"
+  ],
+  "references-count": 0,
+  "URL": "http://dx.doi.org/10.1007/0-306-47144-2_2",
+  "relation": {}
+}

--- a/tests/fixtures/citeproc-book-chapter-2.json
+++ b/tests/fixtures/citeproc-book-chapter-2.json
@@ -1,0 +1,126 @@
+{
+  "indexed": {
+    "date-parts": [
+      [
+        2017,
+        12,
+        6
+      ]
+    ],
+    "date-time": "2017-12-06T09:43:13Z",
+    "timestamp": 1512553393590
+  },
+  "reference-count": 0,
+  "publisher": "S. Karger AG",
+  "content-domain": {
+    "domain": [],
+    "crossmark-restriction": false
+  },
+  "published-print": {
+    "date-parts": [
+      [
+        2016
+      ]
+    ]
+  },
+  "DOI": "10.1159/000446756",
+  "type": "chapter",
+  "created": {
+    "date-parts": [
+      [
+        2016,
+        8,
+        30
+      ]
+    ],
+    "date-time": "2016-08-30T21:08:57Z",
+    "timestamp": 1472591337000
+  },
+  "page": "30-41",
+  "source": "Crossref",
+  "is-referenced-by-count": 3,
+  "title": "Sweat as an Efficient Natural Moisturizer",
+  "prefix": "10.1159",
+  "author": [
+    {
+      "given": "Tetsuo",
+      "family": "Shiohara",
+      "affiliation": []
+    },
+    {
+      "given": "Yohei",
+      "family": "Sato",
+      "affiliation": []
+    },
+    {
+      "given": "Yurie",
+      "family": "Komatsu",
+      "affiliation": []
+    },
+    {
+      "given": "Yukiko",
+      "family": "Ushigome",
+      "affiliation": []
+    },
+    {
+      "given": "Yoshiko",
+      "family": "Mizukawa",
+      "affiliation": []
+    }
+  ],
+  "member": "127",
+  "published-online": {
+    "date-parts": [
+      [
+        2016,
+        8,
+        30
+      ]
+    ]
+  },
+  "container-title": "Perspiration Research",
+  "original-title": [],
+  "link": [
+    {
+      "URL": "http://www.karger.com/Article/Pdf/446756",
+      "content-type": "unspecified",
+      "content-version": "vor",
+      "intended-application": "similarity-checking"
+    }
+  ],
+  "deposited": {
+    "date-parts": [
+      [
+        2017,
+        10,
+        25
+      ]
+    ],
+    "date-time": "2017-10-25T20:04:06Z",
+    "timestamp": 1508961846000
+  },
+  "score": 1,
+  "subtitle": [],
+  "short-title": [],
+  "issued": {
+    "date-parts": [
+      [
+        2016
+      ]
+    ]
+  },
+  "ISBN": [
+    "9783318059045",
+    "9783318059052"
+  ],
+  "references-count": 0,
+  "alternative-id": [
+    "000446756"
+  ],
+  "URL": "http://dx.doi.org/10.1159/000446756",
+  "relation": {},
+  "ISSN": [
+    "1421-5721",
+    "1662-2944"
+  ]
+}

--- a/tests/fixtures/unixref-book-2.xml
+++ b/tests/fixtures/unixref-book-2.xml
@@ -45,43 +45,6 @@
             <resource>http://www.springerlink.com/index/10.1007/978-0-387-72804-9</resource>
           </doi_data>
         </book_metadata>
-        <content_item component_type="chapter" language="en" level_sequence_number="1" publication_type="full_text">
-          <contributors>
-            <person_name contributor_role="author" sequence="first">
-              <given_name>Gabriel J.</given_name>
-              <surname>Costello</surname>
-            </person_name>
-            <person_name contributor_role="author" sequence="additional">
-              <given_name>Brian</given_name>
-              <surname>Donnellan</surname>
-            </person_name>
-            <person_name contributor_role="author" sequence="additional">
-              <given_name>Ivor</given_name>
-              <surname>Gleeson</surname>
-            </person_name>
-            <person_name contributor_role="author" sequence="additional">
-              <given_name>Colm</given_name>
-              <surname>Rochford</surname>
-            </person_name>
-          </contributors>
-          <titles>
-            <title>The Triple Helix, Open Innovation, and the DOI Research Agenda</title>
-          </titles>
-          <component_number>Chapter 32</component_number>
-          <pages>
-            <first_page>463</first_page>
-            <last_page>468</last_page>
-          </pages>
-          <doi_data>
-            <doi>10.1007/978-0-387-72804-9_32</doi>
-            <resource>http://link.springer.com/10.1007/978-0-387-72804-9_32</resource>
-            <collection property="crawler-based" setbyID="springer">
-              <item crawler="iParadigms">
-                <resource>http://www.springerlink.com/index/pdf/10.1007/978-0-387-72804-9_32</resource>
-              </item>
-            </collection>
-          </doi_data>
-        </content_item>
       </book>
     </crossref>
   </doi_record>

--- a/tests/fixtures/unixref-book-chapter-1.xml
+++ b/tests/fixtures/unixref-book-chapter-1.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_records>
+  <doi_record owner="10.1007" timestamp="2014-01-03 09:54:18">
+    <crossref>
+      <book book_type="other">
+        <book_metadata language="en">
+          <contributors>
+            <person_name contributor_role="editor" sequence="first">
+              <given_name>R. Scott</given_name>
+              <surname>Tindale</surname>
+            </person_name>
+            <person_name contributor_role="editor" sequence="additional">
+              <given_name>Linda</given_name>
+              <surname>Heath</surname>
+            </person_name>
+            <person_name contributor_role="editor" sequence="additional">
+              <given_name>John</given_name>
+              <surname>Edwards</surname>
+            </person_name>
+            <person_name contributor_role="editor" sequence="additional">
+              <given_name>Emil J.</given_name>
+              <surname>Posavac</surname>
+            </person_name>
+            <person_name contributor_role="editor" sequence="additional">
+              <given_name>Fred B.</given_name>
+              <surname>Bryant</surname>
+            </person_name>
+            <person_name contributor_role="editor" sequence="additional">
+              <given_name>Yolanda</given_name>
+              <surname>Suarez-Balcazar</surname>
+            </person_name>
+            <person_name contributor_role="editor" sequence="additional">
+              <given_name>Eaaron</given_name>
+              <surname>Henderson-King</surname>
+            </person_name>
+            <person_name contributor_role="editor" sequence="additional">
+              <given_name>Judith</given_name>
+              <surname>Myers</surname>
+            </person_name>
+          </contributors>
+          <series_metadata>
+            <titles>
+              <title>Social Psychological Applications to Social Issues</title>
+            </titles>
+          </series_metadata>
+          <titles>
+            <title>Theory and Research on Small Groups</title>
+          </titles>
+          <volume>4</volume>
+          <publication_date media_type="print">
+            <year>2002</year>
+          </publication_date>
+          <isbn>0-306-45679-6</isbn>
+          <publisher>
+            <publisher_name>Kluwer Academic Publishers</publisher_name>
+            <publisher_place>Boston</publisher_place>
+          </publisher>
+          <doi_data>
+            <doi>10.1007/b108066</doi>
+            <resource>http://www.springerlink.com/index/10.1007/b108066</resource>
+          </doi_data>
+        </book_metadata>
+        <content_item component_type="chapter" language="en" level_sequence_number="1" publication_type="full_text">
+          <contributors>
+            <person_name contributor_role="author" sequence="first">
+              <given_name>David W.</given_name>
+              <surname>Johnson</surname>
+            </person_name>
+            <person_name contributor_role="author" sequence="additional">
+              <given_name>Roger T.</given_name>
+              <surname>Johnson</surname>
+            </person_name>
+          </contributors>
+          <titles>
+            <title>Cooperative Learning and Social Interdependence Theory</title>
+          </titles>
+          <component_number>Chapter 2</component_number>
+          <pages>
+            <first_page>9</first_page>
+            <last_page>35</last_page>
+          </pages>
+          <doi_data>
+            <doi>10.1007/0-306-47144-2_2</doi>
+            <resource>http://link.springer.com/10.1007/0-306-47144-2_2</resource>
+            <collection property="crawler-based" setbyID="springer">
+              <item crawler="iParadigms">
+                <resource>http://www.springerlink.com/index/pdf/10.1007/0-306-47144-2_2</resource>
+              </item>
+            </collection>
+          </doi_data>
+        </content_item>
+      </book>
+    </crossref>
+  </doi_record>
+</doi_records>

--- a/tests/fixtures/unixref-book-chapter-2.xml
+++ b/tests/fixtures/unixref-book-chapter-2.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_records>
+  <doi_record owner="10.1159" timestamp="2017-10-25 16:04:06">
+    <crossref>
+      <book book_type="edited_book">
+        <book_series_metadata language="en">
+          <series_metadata>
+            <titles>
+              <title>Current Problems in Dermatology</title>
+            </titles>
+            <issn media_type="print">1421-5721</issn>
+            <issn media_type="electronic">1662-2944</issn>
+            <doi_data>
+              <doi>10.1159/issn.1421-5721</doi>
+              <resource>http://www.karger.com/BookSeries/Home/223895</resource>
+            </doi_data>
+          </series_metadata>
+          <contributors>
+            <person_name sequence="first" contributor_role="editor">
+              <given_name>H.</given_name>
+              <surname>Yokozeki</surname>
+            </person_name>
+            <person_name sequence="additional" contributor_role="editor">
+              <given_name>H.</given_name>
+              <surname>Murota</surname>
+            </person_name>
+            <person_name sequence="additional" contributor_role="editor">
+              <given_name>I.</given_name>
+              <surname>Katayama</surname>
+            </person_name>
+          </contributors>
+          <titles>
+            <title>Perspiration Research</title>
+          </titles>
+          <volume>51</volume>
+          <publication_date media_type="print">
+            <month>9</month>
+            <day>2</day>
+            <year>2016</year>
+          </publication_date>
+          <isbn media_type="print">978-3-318-05904-5</isbn>
+          <isbn media_type="electronic">978-3-318-05905-2</isbn>
+          <publisher>
+            <publisher_name>S. Karger AG</publisher_name>
+          </publisher>
+          <doi_data>
+            <doi>10.1159/isbn.978-3-318-05905-2</doi>
+            <resource>http://www.karger.com/Book/Home/271839</resource>
+          </doi_data>
+        </book_series_metadata>
+        <content_item component_type="chapter" publication_type="full_text">
+          <contributors>
+            <person_name sequence="first" contributor_role="author">
+              <given_name>Tetsuo</given_name>
+              <surname>Shiohara</surname>
+            </person_name>
+            <person_name sequence="additional" contributor_role="author">
+              <given_name>Yohei</given_name>
+              <surname>Sato</surname>
+            </person_name>
+            <person_name sequence="additional" contributor_role="author">
+              <given_name>Yurie</given_name>
+              <surname>Komatsu</surname>
+            </person_name>
+            <person_name sequence="additional" contributor_role="author">
+              <given_name>Yukiko</given_name>
+              <surname>Ushigome</surname>
+            </person_name>
+            <person_name sequence="additional" contributor_role="author">
+              <given_name>Yoshiko</given_name>
+              <surname>Mizukawa</surname>
+            </person_name>
+          </contributors>
+          <titles>
+            <title>Sweat as an Efficient Natural Moisturizer</title>
+          </titles>
+          <publication_date media_type="print">
+            <year>2016</year>
+          </publication_date>
+          <publication_date media_type="online">
+            <month>8</month>
+            <day>30</day>
+            <year>2016</year>
+          </publication_date>
+          <pages>
+            <first_page>30</first_page>
+            <last_page>41</last_page>
+          </pages>
+          <publisher_item>
+            <identifier id_type="pii">000446756</identifier>
+          </publisher_item>
+          <doi_data>
+            <doi>10.1159/000446756</doi>
+            <timestamp>20160830110115</timestamp>
+            <resource>https://www.karger.com/Article/FullText/446756</resource>
+            <collection property="crawler-based" setbyID="karger">
+              <item crawler="iParadigms">
+                <resource>http://www.karger.com/Article/Pdf/446756</resource>
+              </item>
+            </collection>
+          </doi_data>
+        </content_item>
+      </book>
+    </crossref>
+  </doi_record>
+</doi_records>

--- a/tests/test_citeproc_json.rb
+++ b/tests/test_citeproc_json.rb
@@ -151,6 +151,27 @@ module SimpleDOI
           assert_equal "American Chemical Society", json.publisher
         end
 
+        def test_book_chapter
+          json = CiteprocJSONParser.new File.read("#{fixture_path}/citeproc-book-chapter-1.json")
+          assert_equal 'Theory and Research on Small Groups', json.book_title
+          assert_equal 'Cooperative Learning and Social Interdependence Theory', json.chapter_title
+          assert_equal '0306456796', json.isbn
+          assert_equal 'David W.', json.authors.first.given_name
+          assert_equal 'Kluwer Academic Publishers; Boston', json.publisher
+
+          json = CiteprocJSONParser.new File.read("#{fixture_path}/citeproc-book-chapter-2.json")
+          assert_equal 'Perspiration Research', json.book_title
+          assert_equal 'Sweat as an Efficient Natural Moisturizer', json.chapter_title
+          assert_equal ["9783318059045", "9783318059052"], json.isbns
+        end
+
+        def test_book_chapter_to_h
+          json = CiteprocJSONParser.new File.read("#{fixture_path}/citeproc-book-chapter-1.json")
+          h = json.to_h
+          assert_equal 'Theory and Research on Small Groups', h[:book_title]
+          assert_equal 'Cooperative Learning and Social Interdependence Theory', h[:chapter_title]
+        end
+
         def test_conference_proceeding
           json = CiteprocJSONParser.new File.read("#{fixture_path}/citeproc-conference-2.json")
           assert_equal 'Exact Solutions for In-Plane Displacements of Curved Beams under Thermo Load', json.article_title

--- a/tests/test_unixref_xml.rb
+++ b/tests/test_unixref_xml.rb
@@ -196,7 +196,8 @@ module SimpleDOI
           assert_equal 'Art Vandelay', xml.authors[0].given_name + ' ' + xml.authors[0].surname
           assert_equal 4, xml.editors.count
           assert_equal 'Petrovic', xml.editors.last.surname
-          assert_equal 5, xml.contributors.last.sequence
+          assert_equal 1, xml.contributors.last.sequence
+          # This series lists 4 editors and 1 author
           assert_equal 'author', xml.contributors.last.contributor_role
           assert_equal "997", xml.volume
           assert_equal Date.new(2008, 9, 12), xml.publication_date

--- a/tests/test_unixref_xml.rb
+++ b/tests/test_unixref_xml.rb
@@ -120,7 +120,6 @@ module SimpleDOI
           assert_equal '10.1007/978-0-387-72804-9', xml.doi
           assert_equal 'http://www.springerlink.com/index/10.1007/978-0-387-72804-9', xml.url
           assert_equal '235', xml.volume
-          assert_equal '463-468', xml.pagination
           assert_equal 'Springer US; Boston, MA', xml.publisher
           assert_equal Date.new(2007, 1, 1), xml.publication_date
           assert_equal Hash[year: 2007, month: nil, day: nil], xml.publication_date_hash
@@ -155,7 +154,6 @@ module SimpleDOI
           assert_equal 'http://www.springerlink.com/index/10.1007/978-0-387-72804-9', h[:url]
           assert_equal 4, h[:contributors].count
           assert_equal 'Ferneley', h[:contributors][2][:surname]
-          assert_equal '463-468', h[:pagination]
           assert_equal Date.new(2007, 1, 1), h[:publication_date]
 
           assert_nil h[:issn]

--- a/tests/test_unixref_xml.rb
+++ b/tests/test_unixref_xml.rb
@@ -162,6 +162,27 @@ module SimpleDOI
           assert_nil h[:journal_isoabbrev_title]
         end
 
+        def test_book_chapter
+          xml = UnixrefXMLParser.new File.read("#{fixture_path}/unixref-book-chapter-1.xml")
+          assert_equal 'Theory and Research on Small Groups', xml.book_title
+          assert_equal 'Cooperative Learning and Social Interdependence Theory', xml.chapter_title
+          assert_equal 'Social Psychological Applications to Social Issues', xml.book_series_title
+          assert_equal 'Chapter 2', xml.chapter_number
+          assert_equal '9-35', xml.pagination
+          assert_equal Date.new(2002, 1, 1), xml.publication_date
+          assert_equal '0-306-45679-6', xml.isbn
+          assert_equal 8, xml.editors.count
+          assert_equal 2, xml.authors.count
+          assert_equal 10, xml.contributors.count
+
+          xml = UnixrefXMLParser.new File.read("#{fixture_path}/unixref-book-chapter-2.xml")
+          assert_equal 'Perspiration Research', xml.book_title
+          assert_equal 'Sweat as an Efficient Natural Moisturizer', xml.chapter_title
+          assert_equal 'Current Problems in Dermatology', xml.book_series_title
+          assert_nil xml.chapter_number
+          assert_equal '30-41', xml.pagination
+        end
+
         def test_book_series
           xml = UnixrefXMLParser.new File.read("#{fixture_path}/unixref-bookseries-1.xml")
           assert_equal 'ACS Symposium Series', xml.book_series_title


### PR DESCRIPTION
Adds book chapter (chapter title, chapter number) support.

Additional bugfix for Unixref contributors, where editors, authors, other roles are sequenced individually rather than as a block of _all_ contributor types.